### PR TITLE
Update file_writer()

### DIFF
--- a/jiraone/reporting.py
+++ b/jiraone/reporting.py
@@ -1278,7 +1278,7 @@ def file_writer(folder: str = WORK_PATH, file_name: str = Any, data: Iterable = 
     file = path_builder(path=folder, file_name=file_name)
     encoding = kwargs["encoding"] if "encoding" in kwargs else "utf-8"
     if mode:
-        with open(file, mode, encoding=encoding) as f:
+        with open(file, mode, encoding=encoding, newline='') as f:
             write = csv.writer(f, delimiter=",")
             if mark == "single":
                 write.writerow(data)


### PR DESCRIPTION
CSV file written with Python has blank lines between each row. In Python 3 the required syntax changed, so open 'outfile' with the additional parameter newline='' (empty string) instead.