### PR TITLE
Patch v5 to jiraone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Jira one change log
 
+
+**Release 0.5.6** - 2022-02-02
+### Patch update #73
+* Patch v5 to `time_in_status()`. Noticed that the statuses time were wrong. There seems to be
+a change in the way the previous API payload was retrieved. Tweaked the logic for retrieving 
+accurate difference in time. 
+* The statuses and their time can now be retrieved accurately.
+* The save check_point is turned off for the `time_in_status()` function as a slight logic needs
+to be added to account for when a breakpoint happens between checkpoint to retain
+accurate difference in time between statuses.
+
 **Release 0.5.5** - 2022-01-30
 ### Patch update #72
 * Patch v4 to `time_in_status()`. Noticed the current status not updated on result file.

--- a/jiraone/__init__.py
+++ b/jiraone/__init__.py
@@ -26,7 +26,7 @@ from jiraone.reporting import PROJECT, USER, file_writer, file_reader, path_buil
 from jiraone.management import manage
 
 __author__ = "Prince Nyeche"
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 __all__ = ["LOGIN",
            "endpoint",
            "echo",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="jiraone",
-    version="0.5.5",
+    version="0.5.6",
     author="Prince Nyeche",
     author_email="support@elfapp.website",
     description="A REST API Implementation to Jira Cloud APIs for creating reports and "


### PR DESCRIPTION
* Noticed that the `time_in_status()` was not getting accurate data. It seems that the API payload that was returned in the history changed hence the difference in time was always wrong. Tweaked the logic to accurately calculate the difference in time. Also, the save point feature for the `change_log()` method is turned off when using the `time_in_status()` as to avoid any wrong data during checkpoints.