### PR TITLE
Improve downloading of attachments

### DIFF
--- a/src/jiraone/reporting.py
+++ b/src/jiraone/reporting.py
@@ -518,21 +518,30 @@ class Projects:
         self,
         attachment_folder: str = "Attachment",
         attachment_file_name: str = "attachment_file.csv",
+        mode: str = 'w',
         **kwargs,
     ) -> None:
-        """Return all attachments of a Project or Projects
+        """Fetch the list of all the attachments of a Project or Projects
+        and write it out to an attachment list CSV file named ``attachment_file_name``
+        located in ``attachment_folder``.
 
-        Get the size of attachments on an Issue, count those attachments
-        collectively and return the total number on all Projects searched.
-        JQL is used as a means to search for the project.
+        Also, get the size of the attachment for each Issue, sum up the size of all
+        attachments, and output the total for all Projects as the last
+        row of the output attachment list CSV file.
 
-        :param attachment_folder: A temp folder
+        JQL is used to search for the attachments.
 
-        :param attachment_file_name: A filename for the attachment
+        :param attachment_folder: Target directory where the attachment list CSV
+            file will be written.
 
-        :param kwargs: Addition argument to supply.
+        :param attachment_file_name: Filename of the attachment list CSV to be written.
 
-        :return: None
+        :param mode: Write mode for attachment list CVS to be written. By default it
+            is 'w', which means that any existing file will be overwritten.
+            For example, set to 'a' if you want to append to instead of truncating any
+            existing file.
+
+        :param kwargs: Additional arguments to specify.
         """
         attach_list = deque()
         count_start_at = 0
@@ -551,6 +560,7 @@ class Projects:
             folder=attachment_folder,
             file_name=attachment_file_name,
             data=headers,
+            mode=mode,
             **kwargs,
         )
 

--- a/src/jiraone/reporting.py
+++ b/src/jiraone/reporting.py
@@ -7764,7 +7764,7 @@ def path_builder(
         path,
     )
     if not os.path.exists(base_dir):
-        os.mkdir(base_dir)
+        os.makedirs(base_dir)
         add_log(
             f"Building Path {path}",
             "info",

--- a/src/jiraone/reporting.py
+++ b/src/jiraone/reporting.py
@@ -977,7 +977,11 @@ class Projects:
 
         Calling this method with default arguments assumes that you've
         previously called the ``def get_attachments_on_project()`` method
-        with default arguments
+        with default arguments.
+
+        To avoid conflicts whenever attachments have the same filename (e.g. ``screenshot-1.png``),
+        each downloaded attachment will be placed in a separate directory which corresponds to the
+        content ID that Jira gives the attachment.
 
         :param download_path: the directory where the downloaded attachments are to be stored
 
@@ -1028,19 +1032,23 @@ class Projects:
                 # For example the last line of the attachment list CSV may have:  ,,,,Total Size: 0.09 MB,,,,
                 continue
             fetch = LOGIN.get(attachment)
+            content_id = attachment.split('/')[-1]
+            individual_download_path = os.path.join(download_path, content_id)
+            if not os.path.exists(individual_download_path):
+                os.makedirs(individual_download_path)
             file_writer(
-                download_path,
+                folder=individual_download_path,
                 file_name=_file_name,
                 mode="wb",
                 content=fetch.content,
                 mark="file",
             )
             print(
-                "Attachment downloaded to {}".format(download_path),
+                "Attachment downloaded to {}".format(individual_download_path),
                 "Status code: {}".format(fetch.status_code),
             )
             add_log(
-                "Attachment downloaded to {}".format(download_path),
+                "Attachment downloaded to {}".format(individual_download_path),
                 "info",
             )
             if last_cell is True:

--- a/src/jiraone/reporting.py
+++ b/src/jiraone/reporting.py
@@ -965,45 +965,51 @@ class Projects:
 
     @staticmethod
     def download_attachments(
-        file_folder: str = None,
-        file_name: str = None,
+        file_folder: str = 'Attachment',
+        file_name: str = 'attachment_file.csv',
         download_path: str = "Downloads",
         attach: int = 8,
+        skip_csv_header: bool = True,
         **kwargs,
     ) -> None:
-        """Download the attachments to your local device read from a csv file.
+        """Go through the attachment list CSV file named ``file_name`` and located in the
+        ``file_folder``; for each row, download the attachment indicated to your local device.
 
-        we assume you're getting this from ``def get_attachments_on_project()``
-        method.
+        Calling this method with default arguments assumes that you've
+        previously called the ``def get_attachments_on_project()`` method
+        with default arguments
 
-        :param attach: integers to specify the index of the columns
+        :param download_path: the directory where the downloaded attachments are to be stored
 
-        :param file_folder: a folder or directory where the file extract exist
+        :param file_folder: the directory where the attachment list CSV file can be found
+            (Default corresponds to the output of ``def get_attachments_on_project()``
+            when called with default arguments)
 
-        :param download_path: a directory where files are stored
+        :param file_name: file name of the attachment list CSV file
+            (Default corresponds to the output of ``def get_attachments_on_project()``
+            when called with default arguments)
 
-        :param file_name: a file name to a file
+        :param attach: index of the column that corresponds to 'Attachment URL' in the attachment
+            list CSV file.
+            (Default is 8, which corresponds to the output of ``def get_attachments_on_project()``)
 
-                e.g
-                  * attach=6,
-                  * file=8
+        :param skip_csv_header: when set to True, skips the first line of the attachment list CSV file; i.e.
+            assumes that the first line represents a header row.
+            (Default is True, which corresponds to the output of ``def get_attachments_on_project()``)
 
         :param kwargs: Additional keyword argument
 
                         **Acceptable options**
 
-                        * file: A row to the index of the column
-
-        the above example corresponds with the index if using the
-        ``def get_attachments_on_project()`` otherwise, specify your value
-        in each keyword args when calling the method.
-
-        :return: None
+                        * file: index of the column 'Name of file' in the attachment list CSV file.
+                            (Default is 6, which corresponds to the output of
+                            ``def get_attachments_on_project()``)
         """
         file: int = kwargs.get("file", 6)
         read = file_reader(
             folder=file_folder,
             file_name=file_name,
+            skip=skip_csv_header,
             **kwargs,
         )
         add_log(
@@ -1018,6 +1024,9 @@ class Projects:
             count += 1
             attachment = r[attach]
             _file_name = r[file]
+            if attachment == '' or _file_name == '':
+                # For example the last line of the attachment list CSV may have:  ,,,,Total Size: 0.09 MB,,,,
+                continue
             fetch = LOGIN.get(attachment)
             file_writer(
                 download_path,

--- a/src/jiraone/reporting.py
+++ b/src/jiraone/reporting.py
@@ -5840,7 +5840,7 @@ class Projects:
                                 {f"{sprint_item[sub_sprint]}": []}
                             )
 
-                if "customType" in sprint_custom_id:
+                if sprint_custom_id is not None and "customType" in sprint_custom_id:
                     if sprint_custom_id["customType"].endswith("gh-sprint"):
                         extract = sprint_custom_id["id"].split("_")
                         config["sprint_cf"] = "cf[{}]".format(extract[1])


### PR DESCRIPTION
Fixes:

- 🐛 `get_attachments_on_projects`: Overwrite attachment file by default
- 🐛 `json_field_builder`: check if `sprint_custom_id` is None
- 🐛 `path_builder`: handle multi-dir base_dir
- 🐛 `download_attachments`: avoid conflicts/overwrites by isolating attachments (helps with https://github.com/princenyeche/jiraone/issues/112)

Improvements:

- ✨ `download_attachments`: make defaults and behavior match `get_attachments_on_projects`

Features:

- ✨ `download_attachments`: support `create_html_directors` option (resolves https://github.com/princenyeche/jiraone/issues/112)
- ✨ `download_attachments`: support `overwrite=False` option (to speed up incremental backups)

----

Let me know if you want me to split these commits into separate PRs